### PR TITLE
added metric for ooo lag for each datapoint

### DIFF
--- a/carbon/app.go
+++ b/carbon/app.go
@@ -311,7 +311,9 @@ func (app *App) startPersister() {
 		p.SetRemoveEmptyFile(app.Config.Whisper.RemoveEmptyFile)
 		p.SetWorkers(app.Config.Whisper.Workers)
 		p.SetHashFilenames(app.Config.Whisper.HashFilenames)
-
+		if app.Config.Prometheus.Enabled {
+			p.InitPrometheus(app.PromRegisterer)
+		}
 		if app.Tags != nil {
 			p.SetTagsEnabled(true)
 			p.SetTaggedFn(app.Tags.Add)

--- a/persister/whisper.go
+++ b/persister/whisper.go
@@ -213,7 +213,7 @@ func fnv32(key string) uint32 {
 	}
 	return hash
 }
-func (p *Whisper) registerOutOfOrderLags(points []*whisper.TimeSeriesPoint) {
+func (p *Whisper) registerOutOfOrderWriteLags(points []*whisper.TimeSeriesPoint) {
 	if !p.prometheus.enabled {
 		return
 	}
@@ -234,7 +234,7 @@ func (p *Whisper) updateMany(w *whisper.Whisper, path string, points []*whisper.
 	}()
 
 	// start = time.Now()
-	p.registerOutOfOrderLags(points)
+	p.registerOutOfOrderWriteLags(points)
 	if err := w.UpdateMany(points); err != nil {
 		p.logger.Error("fail to update metric",
 			zap.String("path", path),


### PR DESCRIPTION
we receive OOO writes in graphite storage, we need to understand how far they are in the past in order to suggest possible solutions for OOO for cwhisper. In this PR I added prometheus histogram metric for OOO lag for each datapoint.
 Tested on prod box, I didn't notice any performance impact