### PR TITLE
 fix: use errors.As instead of errors.Is for errorNotFound in find HTTP handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ sha256sum
 *.rpm
 *.deb
 /local/
+.omc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,144 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+## What This Is
+
+go-carbon is a high-performance Golang implementation of Graphite's carbon-cache daemon. It receives metrics via multiple protocols (TCP, UDP, Pickle, HTTP, Kafka, PubSub), buffers them in a sharded in-memory cache, and persists them to Whisper (.wsp) files. Also serves a read API (carbonserver) compatible with graphite-web and carbonapi.
+
+## Build & Test Commands
+
+```bash
+make                    # Build the go-carbon binary
+make test               # Run tests, vet, and race detection (all three)
+go test ./...           # Run tests only (faster iteration)
+go test -race ./...     # Run tests with race detector
+go vet ./...            # Run vet only
+go test -run TestName ./package/  # Run a single test
+make image              # Build Docker image (requires Linux binary)
+```
+
+Dependencies use vendoring (`-mod=vendor` is set via GOFLAGS in the Makefile). Run `go mod tidy && go mod vendor` when updating dependencies.
+
+## Linting
+
+CI uses golangci-lint v2. Config is in `.golangci.yml`. Enabled linters: gocritic, ineffassign, asciicheck, misspell, promlinter, errorlint, govet, unparam, bodyclose, gochecknoinits. Formatters: gofmt, goimports.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `go-carbon.go` | Entry point: CLI flags, signal handling, daemon mode, starts the `carbon.App` |
+| `go-carbon.conf.example` | Full annotated configuration reference (TOML format) |
+| `Makefile` | Build, test, lint, packaging, Docker image targets |
+| `go.mod` | Go module definition (`github.com/go-graphite/go-carbon`) |
+| `.golangci.yml` | golangci-lint v2 config with enabled linters |
+| `nfpm.yaml` | Package builder config for deb/rpm generation |
+| `Dockerfile` | Production container image |
+| `Dockerfile.debug` | Debug container with Delve support |
+
+## Architecture
+
+### Data Flow
+```
+Receivers (TCP/UDP/Pickle/HTTP/Kafka/PubSub)
+    │
+    ▼
+  Cache (sharded concurrent map, 1024 shards)
+    │
+    ├──▶ Persister (worker pool writes to Whisper .wsp files)
+    │
+    ├──▶ CarbonLink (legacy pickle protocol for cache reads)
+    │
+    └──▶ Carbonserver (HTTP/gRPC read API with trigram/trie index)
+```
+
+### Core Pipeline
+
+- **`points/`** - The fundamental data type: `Points{Metric string, Data []Point}` where `Point{Value float64, Timestamp int64}`. Flows through the entire pipeline.
+
+- **`receiver/`** - Plugin-based metric ingestion. Each protocol (TCP, UDP, Pickle, HTTP, Kafka, PubSub) registers via `receiver.Register()` and is instantiated at startup. Protocols are wired in `carbon/app.go` with `registerPluginsOnce`. Custom receivers are configured via TOML `[[receiver.*]]` sections.
+
+- **`cache/`** - Sharded concurrent map (1024 shards) that buffers incoming points. Three write strategies: `max` (most unwritten points first), `sorted` (by timestamp), `noop` (unspecified order). The `WriteoutQueue` feeds metrics to the persister. Optional bloom filter for new metric detection.
+
+- **`persister/`** - Writes cached points to Whisper `.wsp` files. Configurable worker count (metrics sharded by `crc32(metricName) % workers`). Handles storage-schemas.conf and storage-aggregation.conf parsing. Supports online migration of Whisper file configurations.
+
+- **`carbonserver/`** - HTTP+gRPC read API serving find/render/info requests to graphite-web or carbonapi. Two index types: **trigram** (default, uses trigram indexing for glob matching) and **trie** (better for 10M+ metrics, uses DFA-based matching). Supports query/find/glob caches, rate limiting, and quota enforcement.
+
+### Supporting Packages
+
+- **`carbon/`** - Application orchestrator. `App` struct owns all components and manages lifecycle (start, stop, config reload). `Config` is TOML-based (parsed via `BurntSushi/toml`).
+- **`api/`** - gRPC API for cache queries (CarbonLink-like).
+- **`tags/`** - Tag normalization and external TagDB integration.
+- **`helper/`** - Protobuf definitions (`carbonpb/`, `carbonzipperpb/`), stats, throttling, file utilities.
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `carbon/` | Application orchestrator — `App` struct, config parsing, component lifecycle (see `carbon/AGENTS.md`) |
+| `receiver/` | Plugin-based metric ingestion for all protocols (see `receiver/AGENTS.md`) |
+| `cache/` | Sharded in-memory metric buffer between receivers and persister (see `cache/AGENTS.md`) |
+| `persister/` | Whisper file writer with schema/aggregation matching (see `persister/AGENTS.md`) |
+| `carbonserver/` | HTTP+gRPC read API for find/render/info with trigram and trie indexes (see `carbonserver/AGENTS.md`) |
+| `points/` | Core data types: `Point` and `Points` used throughout the pipeline (see `points/AGENTS.md`) |
+| `api/` | gRPC API for cache queries (CarbonLink-like protocol) (see `api/AGENTS.md`) |
+| `helper/` | Shared utilities: protobuf defs, stats, throttling, file ops (see `helper/AGENTS.md`) |
+| `tags/` | Graphite tag normalization and external TagDB integration (see `tags/AGENTS.md`) |
+| `deploy/` | Systemd service, init script, logrotate, default config files for packaging |
+| `tool/` | Standalone CLI tools for operational tasks (see `tool/AGENTS.md`) |
+| `doc/` | Architecture diagrams and additional documentation |
+
+## Common Patterns
+
+- Config format is TOML (parsed via `BurntSushi/toml`), not YAML or JSON
+- Dependencies are vendored: always use `go mod tidy && go mod vendor` after changes
+- `GOFLAGS=-mod=vendor` is set in the Makefile — all go commands respect vendoring
+- Version is `const Version` in `go-carbon.go`, build version injected via ldflags
+- The receiver system uses a plugin registry pattern — protocols self-register via `init()` or explicit `Register()` calls
+- Components implement start/stop lifecycle managed by `carbon.App` using `helper.Stoppable`
+- Stats are collected via a `Collector` that gathers metrics from all components
+- Prometheus metrics are optional (gated by `prometheus.enabled` config)
+- Logging uses `lomik/zapwriter` (structured zap-based logging with rotation)
+- Graceful shutdown flows: `App.stopListeners()` → `App.stopAll()`
+
+## Signal Handling
+
+- **SIGHUP** → config reload (whisper settings, schemas, aggregation, common, dump sections)
+- **SIGUSR2** → graceful dump-and-stop (dump cache to disk, exit; restored on next start)
+
+## Configuration
+
+Config format is TOML. See `go-carbon.conf.example` for all options. Key config files:
+- Main config: `go-carbon.conf` (TOML)
+- `storage-schemas.conf` - Retention policies (standard Graphite format)
+- `storage-aggregation.conf` - Aggregation methods (standard Graphite format)
+- `storage-quotas.conf` - Optional, go-carbon specific (see `doc/quotas.md`)
+
+Version is defined as `const Version` in `go-carbon.go`. Build version is injected via `-ldflags '-X main.BuildVersion=...'`.
+
+## CI
+
+GitHub Actions runs on push to master and PRs:
+- Tests with Go oldstable + stable, including race detector
+- golangci-lint v2
+- Docker image build
+- Package builds (deb/rpm via nfpm for i386, amd64, arm64)
+- govulncheck on stable Go
+
+## Dependencies (Key External)
+
+- `go-graphite/go-whisper` — Whisper file format library
+- `go-graphite/protocol` — Protobuf definitions for carbonapi v2/v3
+- `go-graphite/carbonzipper` — Shared protobuf types
+- `BurntSushi/toml` — TOML config parser
+- `lomik/zapwriter` — Structured logging with file rotation
+- `prometheus/client_golang` — Prometheus metrics exposition
+- `IBM/sarama` — Apache Kafka client
+- `cloud.google.com/go/pubsub` — Google Cloud Pub/Sub client
+- `syndtr/goleveldb` — LevelDB for carbonserver file list cache
+- `dgryski/go-trigram` — Trigram index for metric name glob matching
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -1,0 +1,53 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# api
+
+## Purpose
+Provides a gRPC API for cache queries, implementing a CarbonLink-compatible interface over gRPC. Allows external tools (e.g. carbonapi) to query in-memory metric data points from the write cache before they are persisted to disk.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `api.go` | `Api` struct: wraps a gRPC server, implements `carbonpb.CarbonServer`. Methods: `New()`, `Listen()`, `Stop()`, `Addr()`, `Stat()`, `CacheQuery()`. Tracks per-request counters atomically. |
+| `sample/cache-query/cache-query.go` | Standalone CLI client for manual testing of the gRPC cache query API. Connects to a running go-carbon instance and queries named metrics. |
+
+## Subdirectories
+| Directory | Purpose |
+|-----------|---------|
+| `sample/cache-query/` | Example gRPC client binary (`cache-query`); not imported by any other package |
+
+## For AI Agents
+
+### Working In This Directory
+- `Api` embeds `stop.Struct` (from `lomik/stop`), not `helper.Stoppable` — use `StartFunc`/`Go` patterns from that package.
+- The gRPC server is registered with `carbonpb.RegisterCarbonServer` and gRPC reflection. The only RPC method is `CacheQuery`.
+- Stats counters (`cacheRequests`, `cacheRequestMetrics`, `cacheResponseMetrics`, `cacheResponsePoints`) use `sync/atomic` and are drained (subtract-and-send) via `helper.SendAndSubstractUint32`.
+- The default port for the gRPC API is `7003` (see `sample/cache-query/cache-query.go` default flag).
+- Do not add new RPC methods without updating `helper/carbonpb/carbon.proto` and regenerating the pb file.
+
+### Testing Requirements
+```
+go test ./api/
+```
+No test files currently exist in `api/`; the `sample/` binary can be used for manual integration testing against a live instance.
+
+### Common Patterns
+- Goroutine lifecycle via `api.Go(func(exit chan struct{}) { ... })` — goroutines watch the `exit` channel for shutdown.
+- All stat increments use `atomic.AddUint32`.
+- gRPC server is stopped on exit via a dedicated goroutine that waits on the exit channel.
+
+## Dependencies
+
+### Internal
+- `cache/` — `*cache.Cache` is the only data source; queried via `cache.Get(metric)`
+- `helper/` — `helper.StatCallback`, `helper.SendAndSubstractUint32`
+- `helper/carbonpb/` — generated gRPC service and message types
+
+### External
+- `github.com/lomik/stop` — provides `stop.Struct` with `StartFunc`/`Go` lifecycle
+- `google.golang.org/grpc` — gRPC server
+- `google.golang.org/grpc/reflection` — gRPC server reflection (for tooling like grpcurl)
+- `golang.org/x/net/context` — context package
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/cache/AGENTS.md
+++ b/cache/AGENTS.md
@@ -1,0 +1,61 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# cache
+
+## Purpose
+Sharded in-memory buffer that sits between receivers and the persister. Receivers write points in via `Add()`; the persister reads them out via `WriteoutQueue` / `Pop()`; carbonserver reads live (unflushed) data via `Get()`. Designed for high write concurrency through CRC32-based sharding across 1024 independent `Shard` structs, each with its own `sync.RWMutex`.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `cache.go` | `Cache` struct and `Shard` struct; `Add()`, `Pop()`, `PopNotConfirmed()`, `Get()`, `Confirm()`; bloom filter for new-metric detection; throttle hook; `Stat()` for internal metrics |
+| `writeout_queue.go` | `WriteoutQueue` orders metric keys for the persister; rebuilds lazily when drained; respects `WriteStrategy` ordering via `makeQueue()` |
+| `queue.go` | `makeQueue()` — builds the ordered channel of metric keys based on write strategy (`MaximumLength`, `TimestampOrder`, `Noop`) |
+| `carbonlink.go` | `CarbonlinkListener` — legacy pickle-protocol TCP server; allows graphite-web to query cached (not-yet-persisted) data points via `cache-query` requests |
+| `dump.go` | `Dump()` (plain text) and `DumpBinary()` (varint-encoded) — iterate all shards including `notConfirmed` slice, write to `io.Writer` for graceful restart |
+| `confirm.go` | `Confirm()` removes a `*points.Points` from the `notConfirmed` slice after successful persister write |
+| `cache_test.go` | Unit tests for Add/Pop/Get and overflow behaviour |
+| `dump_test.go` | Round-trip dump/restore tests |
+| `confirm_test.go` | Tests for the confirm/notConfirmed flow |
+| `carbonlink_test.go` | Tests for pickle request parsing and reply encoding |
+| `xlog_test.go` | Tests for xlog (write-ahead log) diversion via `DivertToXlog()` |
+
+## For AI Agents
+
+### Working In This Directory
+- Shard selection is `crc32(metricName) & 1023` — implemented in `helper.HashString`. Never assume a metric maps to a specific shard in tests.
+- The `notConfirmed` mechanism exists to prevent data loss: `PopNotConfirmed()` removes a metric from `shard.items` but keeps the pointer in `shard.notConfirmed`. The persister calls `Confirm()` only after a successful whisper write. `Get()` scans both `items` and `notConfirmed` to return all live data.
+- `Pop()` (used when confirmation is disabled) does a plain delete with no safety net. `PopNotConfirmed()` / `Confirm()` is the safe path used by the whisper persister.
+- `DivertToXlog(w)` switches `Add()` to write plain-text lines to `w` instead of buffering in memory. Used by `DumpStop()` to capture incoming points while the cache is being serialized.
+- Settings (`maxSize`, `xlog`, `tagsEnabled`) are stored in an `atomic.Value`-wrapped `cacheSettings` struct — copy-on-write, never mutate in place.
+- Bloom filter (`newMetricCf`) tracks whether a metric has been seen before. When set, `Add()` only sends to `newMetricsChan` on a bloom miss, reducing channel pressure for existing metrics.
+- `WriteoutQueue.Get(abort)` blocks until a metric key is available or `abort` is closed. It rebuilds the queue channel lazily with a 100ms debounce between rebuilds.
+- `WriteStrategy` values map from TOML strings: `"max"` → `MaximumLength`, `"sorted"` → `TimestampOrder`, `"noop"` → `Noop`.
+- The carbonlink protocol uses Python pickle encoding (protocols 2, 3, 4, 5). The parser in `carbonlink.go` handles all variants. Do not simplify it.
+
+### Testing Requirements
+```
+go test ./cache/
+```
+No external dependencies required. Tests are self-contained with in-memory cache instances.
+
+### Common Patterns
+- Shard lock discipline: always `shard.mu.Lock()` for writes, `shard.mu.RLock()` for reads. Never hold the cache-level `c.mu` (used only for `writeStrategy` changes) while holding a shard lock.
+- Atomic counters for stats: `atomic.AddUint32(&c.stat.overflowCnt, ...)`, `atomic.AddInt64(&c.stat.size, ...)`. Stats are read in `Stat()` via `helper.SendAndSubstractUint32` (delta reporting) or `helper.SendUint32` (cumulative).
+- `helper.Stoppable` embedded in `CarbonlinkListener` for goroutine lifecycle management (`Go()`, `Stop()`, `StartFunc()`).
+
+## Dependencies
+
+### Internal
+- `github.com/go-graphite/go-carbon/helper` — `Stoppable`, `StatCallback`, `HashString`, `SendAndSubstractUint32`
+- `github.com/go-graphite/go-carbon/points` — `Points`, `Point` types; `WriteTo()`, `WriteBinaryTo()`
+- `github.com/go-graphite/go-carbon/tags` — `tags.Normalize()` called in `Add()` when tags are enabled
+
+### External
+- `github.com/greatroar/blobloom` — blocked bloom filter for new-metric detection
+- `github.com/lomik/graphite-pickle/framing` — framed TCP connection for carbonlink pickle protocol
+- `go.uber.org/zap` — structured logging
+- `github.com/lomik/zapwriter` — logger retrieval by name
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/carbon/AGENTS.md
+++ b/carbon/AGENTS.md
@@ -1,0 +1,62 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# carbon
+
+## Purpose
+Application orchestrator for go-carbon. Owns all top-level components and controls their lifecycle: startup, shutdown, config reload, and graceful dump/restore. This is the entry point package — `main` constructs an `App` and calls `Start()`, `Loop()`, and `Stop()`.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `app.go` | `App` struct owning all components; `New()`, `Start()`, `Stop()`, `Loop()`, `ReloadConfig()`, `configure()`, `startPersister()` |
+| `config.go` | `Config` struct with TOML tags; `ReadConfig()`, `NewConfig()`, `PrintDefaultConfig()`; `Duration` wrapper for TOML time parsing |
+| `collector.go` | `Collector` gathers stats from all components at `MetricInterval`; implements `statModule` interface via `Stat(send StatCallback)`; sends internal metrics either to local cache or remote TCP/UDP endpoint |
+| `grace.go` | `DumpStop()` for SIGUSR2 graceful restart — diverts cache writes to xlog, dumps binary cache to disk, stops listeners; `Restore()` / `RestoreFromDir()` / `RestoreFromFile()` for reading dump files back into cache on startup |
+| `app_stop_test.go` | Tests for clean shutdown ordering |
+| `restore_test.go` | Tests for dump/restore round-trip |
+
+## For AI Agents
+
+### Working In This Directory
+- `App` is the single authoritative owner of all component pointers. Always acquire `app.Lock()` before reading/writing component fields outside of `Start()`.
+- `ReloadConfig()` only recreates `Persister`, `Tags`, and `Collector` — it does not restart receivers or carbonserver. Do not broaden this scope without understanding the startup ordering in `Start()`.
+- `startPersister()` is called both from `Start()` and `ReloadConfig()`. Keep it free of side effects that must not run twice.
+- `Collector` must be re-created on every config reload (comment in `App` struct is authoritative).
+- The `DumpStop()` flow is order-sensitive: stop persister → divert cache to xlog → dump cache → stop listeners → flush xlog. Do not reorder.
+- `grace.go` sorts dump files by nanotimestamp with `cache.*` before `input.*` at the same timestamp to ensure correct restore order.
+- `Duration` in `config.go` is a TOML-aware wrapper around `time.Duration`; always call `.Value()` to get the underlying duration.
+- Config sections are unexported structs (`commonConfig`, `whisperConfig`, etc.) embedded in the exported `Config`.
+
+### Testing Requirements
+```
+go test ./carbon/
+```
+Tests require a writable temp directory (created via `carbon.TestConfig(rootDir)`).
+
+### Common Patterns
+- Component lifecycle: check `if app.X != nil { app.X.Stop(); app.X = nil }` before re-creating.
+- All components that expose stats implement `statModule` interface: `Stat(send helper.StatCallback)`.
+- Receivers are registered once via `registerPluginsOnce.Do(...)` in `New()`.
+- Config-driven feature flags: each major subsystem has an `Enabled bool` TOML field checked before initialization.
+- Logging via `zapwriter.Logger("component-name")`, structured fields with `zap.String`, `zap.Error`, `zap.Duration`.
+
+## Dependencies
+
+### Internal
+- `github.com/go-graphite/go-carbon/api` — gRPC API server
+- `github.com/go-graphite/go-carbon/cache` — in-memory metric buffer
+- `github.com/go-graphite/go-carbon/carbonserver` — HTTP/gRPC read server
+- `github.com/go-graphite/go-carbon/helper` — `Stoppable`, `StatCallback`, throttle ticker
+- `github.com/go-graphite/go-carbon/persister` — whisper write workers
+- `github.com/go-graphite/go-carbon/points` — core data types
+- `github.com/go-graphite/go-carbon/receiver` — receiver plugin registry and built-in receivers
+- `github.com/go-graphite/go-carbon/tags` — tag normalization and TagDB sync
+
+### External
+- `github.com/BurntSushi/toml` — config file parsing
+- `github.com/prometheus/client_golang/prometheus` — Prometheus metrics registry
+- `github.com/lomik/zapwriter` — structured logger configuration
+- `go.uber.org/zap` — structured logging
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/carbonserver/AGENTS.md
+++ b/carbonserver/AGENTS.md
@@ -1,0 +1,90 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# carbonserver
+
+## Purpose
+Implements the HTTP and gRPC read API for go-carbon, providing Graphite-compatible
+metric discovery and data retrieval. Manages a metric index (trigram or trie),
+file list cache (FLC), query caches, rate limiting, and quota enforcement.
+This is the largest package in go-carbon.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `carbonserver.go` | `CarbonserverListener` — core HTTP/gRPC server. Registers all HTTP endpoints, manages index lifecycle, file list cache, query caches, rate limiting, and Prometheus metrics. |
+| `trie.go` | Trie-based metric index with DFA glob matching. Preferred for 10M+ metrics. Compiles NFA glob patterns to DFA at query time for efficient traversal. |
+| `find.go` | `/metrics/find/` endpoint — glob-based metric discovery. |
+| `render.go` | `/render/` endpoint — fetches time-series data for matched metrics. |
+| `list.go` | `/metrics/list/` endpoint — enumerates all known metrics. |
+| `details.go` | `/metrics/details/` endpoint — returns metric metadata. |
+| `info.go` | `/metrics/info/` endpoint — returns whisper file info (retentions, aggregation). |
+| `fetchfromdisk.go` | Reads data points from `.wsp` whisper files on disk. |
+| `fetchfromcache.go` | Reads in-flight data points from the in-memory cache. |
+| `fetchsinglemetric.go` | Orchestrates disk + cache fetch and merges the results. |
+| `flc.go` | File list cache — persists the metric index to LevelDB for fast restarts. |
+| `format.go` | Response format handling: JSON, Protocol Buffers, pickle. |
+| `pickle.go` | Python pickle encoding for Graphite wire compatibility. |
+| `capability.go` | Reports server capabilities to clients. |
+| `trace.go` | Per-request tracing support. |
+| `trie_test.go` | Unit tests for trie index. |
+| `trie_real_test.go` | Integration-style trie tests using real metric sets. |
+| `trie_fuzz_index.go` | Fuzz target for trie index construction. |
+| `trie_fuzz_query.go` | Fuzz target for trie glob queries. |
+| `cache_index_test.go` | Tests for cache-based index operations. |
+| `carbonserver_test.go` | General carbonserver tests. |
+| `flc_test.go` | File list cache tests. |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- Two index backends exist: **trigram** (`dgryski/go-trigram`) and **trie** (`trie.go`). The trie is preferred for large installations (10M+ metrics) and uses NFA-to-DFA compilation for glob patterns. Select via `use-trie-index` config option.
+- The index is rebuilt on a `scan-frequency` interval by scanning the whisper root directory. During a rebuild the old index remains live; the new one is swapped atomically.
+- The file list cache (FLC, `flc.go`) persists the index to LevelDB so restarts avoid a full filesystem scan. It is keyed by file path with bloom filters enabled.
+- Data fetching pipeline: `fetchsinglemetric.go` calls `fetchfromdisk.go` and `fetchfromcache.go` in parallel, then merges, with cache points taking priority over disk points for the same timestamp.
+- Rate limiting: `ApiPerPathRatelimiter` limits by HTTP path; `GlobQueryRateLimiter` limits concurrent glob expansions. Both reject with HTTP 429 when the limit is exceeded.
+- gRPC is served alongside HTTP on the same port using `grpc.Server` with `carbonapi_v2_grpc` and `carbonapi_v3_pb` protocols. Do not add HTTP-only logic to the gRPC handlers or vice versa.
+- Quota enforcement integrates with `persister.WhisperQuotas`; quota checks happen at query time, not just at write time.
+- All handler functions follow the pattern: parse request → check rate limit → resolve globs via index → fetch data → encode response in requested format.
+
+### Testing Requirements
+```
+go test ./carbonserver/
+```
+Fuzz targets can be run with:
+```
+go test -fuzz=FuzzTrieIndex ./carbonserver/
+go test -fuzz=FuzzTrieQuery ./carbonserver/
+```
+
+### Common Patterns
+- HTTP handlers use `httputil` wrappers and return structured errors with Prometheus counter increments before returning.
+- `metricStruct` holds all internal counters as `uint64` fields updated via `atomic.AddUint64` — never use a mutex to update these.
+- Response format is negotiated from the `format` query parameter and the `Accept` header; use `format.go` helpers, do not add ad-hoc format switches.
+- Structured logging via `go.uber.org/zap` with request-scoped logger fields (path, remote addr, query).
+- gRPC errors use `google.golang.org/grpc/status` codes, not raw `error` returns.
+- `QueryItem` with `atomic.Value` and a `QueryFinished` channel implements request coalescing for identical in-flight glob queries.
+
+## Dependencies
+
+### Internal
+- `github.com/go-graphite/go-carbon/helper` — `StatCallback`, `Stoppable`, `grpcutil`, `stat`
+- `github.com/go-graphite/go-carbon/points` — `Points` for cache reads
+- `github.com/go-graphite/go-carbon/helper/grpcutil` — gRPC server utilities
+
+### External
+- `github.com/dgryski/go-trigram` — Trigram index backend
+- `github.com/dgryski/go-expirecache` — TTL-based query result cache
+- `github.com/syndtr/goleveldb/leveldb` — LevelDB for file list cache persistence
+- `github.com/go-graphite/protocol/carbonapi_v2_grpc` — gRPC v2 protocol
+- `github.com/go-graphite/protocol/carbonapi_v3_pb` — Protobuf v3 protocol
+- `google.golang.org/grpc` — gRPC server runtime
+- `github.com/NYTimes/gziphandler` — gzip HTTP middleware
+- `github.com/prometheus/client_golang/prometheus` — Prometheus metrics
+- `go.uber.org/zap` — Structured logging
+- `github.com/lomik/zapwriter` — zap writer initialization
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/carbonserver/find.go
+++ b/carbonserver/find.go
@@ -151,7 +151,7 @@ func (listener *CarbonserverListener) findHandler(wr http.ResponseWriter, req *h
 		var code int
 		var reason string
 		var nf errorNotFound
-		if errors.Is(err, &nf) {
+		if errors.As(err, &nf) {
 			reason = "Not Found"
 			code = http.StatusNotFound
 		} else {

--- a/helper/AGENTS.md
+++ b/helper/AGENTS.md
@@ -1,0 +1,62 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# helper
+
+## Purpose
+Shared utilities and infrastructure used across the go-carbon codebase. Provides lifecycle management for long-running components (`Stoppable`), rate limiting (`ThrottleTicker`), atomic stat helpers, platform-specific file stat types, generated protobuf code, gRPC utilities, atomic file writes, and test helpers.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `stoppable.go` | `Stoppable` struct — base type for long-running components. Provides `Start()`, `Stop()`, `StartFunc()`, `StopFunc()`, and goroutine launcher `Go`. Embedded by most subsystems in go-carbon. |
+| `throttle.go` | `ThrottleTicker` — rate-limiting ticker with soft (`NewThrottleTicker`) and hard (`NewHardThrottleTicker`) modes. Used to cap max-updates-per-second in the persister. |
+| `throttle_test.go` | Unit tests for `ThrottleTicker`. |
+| `atomic_utils.go` | Atomic stat helpers: `SendAndSubstractUint32/64`, `SendUint32/64`, `SendAndZeroIfNotUpdatedUint32`. Defines `StatCallback` type `func(string, float64)`. |
+| `hash.go` | Hash utility functions. |
+| `hash_test.go` | Tests for hash utilities. |
+
+## Subdirectories
+| Directory | Purpose |
+|-----------|---------|
+| `atomicfiles/` | See [atomicfiles/AGENTS.md](atomicfiles/AGENTS.md) — atomic file write via temp-file + rename |
+| `carbonpb/` | See [carbonpb/AGENTS.md](carbonpb/AGENTS.md) — generated protobuf/gRPC for the carbon cache-query protocol |
+| `carbonzipperpb/` | See [carbonzipperpb/AGENTS.md](carbonzipperpb/AGENTS.md) — generated protobuf for the carbonzipper protocol |
+| `grpcutil/` | See [grpcutil/AGENTS.md](grpcutil/AGENTS.md) — gRPC server interceptors for timing and status metrics |
+| `qa/` | See [qa/AGENTS.md](qa/AGENTS.md) — test helper for creating and cleaning up temp directories |
+| `stat/` | See [stat/AGENTS.md](stat/AGENTS.md) — platform-specific file stat types (`FileStats` with Size, RealSize, ATime, CTime, MTime) |
+
+## For AI Agents
+
+### Working In This Directory
+- `Stoppable` uses an internal `exit chan bool` (closed on stop) and a `sync.WaitGroup`. All goroutines launched with `s.Go(func(exit chan bool))` must return when `exit` is closed.
+- `ThrottleTicker.C` is a `chan bool`. Soft mode: sends `true` at the target rate. Hard mode: sends `true` for the first N per second, then nothing — callers must handle backpressure themselves.
+- `StatCallback` is the universal stats reporting type; all packages use `helper.SendAndSubstractUint32` (counter-style, drains after read) or `helper.SendUint32` (gauge-style).
+- Do not add business logic here. This package has no knowledge of metrics storage or network protocols.
+- Protobuf files in `carbonpb/` and `carbonzipperpb/` are generated — edit `.proto` files and run `go generate` via the `gen.go` files, do not hand-edit `.pb.go` files.
+
+### Testing Requirements
+```
+go test ./helper/...
+```
+Tests exist for `throttle.go` and `hash.go`. The `qa/` subpackage is a test helper (imported only in `_test.go` files).
+
+### Common Patterns
+- Embed `helper.Stoppable` in any struct that needs start/stop lifecycle.
+- Launch goroutines with `s.Go(func(exit chan bool) { ... select { case <-exit: return } ... })`.
+- Report stats with `helper.SendAndSubstractUint32("metricName", &s.stat.counter, send)` inside a `Stat(send helper.StatCallback)` method.
+- Atomic file writes: write to temp file in same directory, sync, close, then `os.Rename` — guaranteed by `atomicfiles.WriteFile`.
+
+## Dependencies
+
+### Internal
+None — `helper` has no imports from other go-carbon packages. It is a leaf dependency.
+
+### External
+- `sync`, `sync/atomic` — standard library concurrency primitives
+- `time` — standard library (used in throttle)
+- `os`, `path` — standard library (used in atomicfiles, qa)
+- `google.golang.org/grpc` — gRPC framework (used in grpcutil)
+- `github.com/gogo/protobuf` / `github.com/golang/protobuf` — protobuf runtime (used in generated pb files)
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/helper/atomicfiles/AGENTS.md
+++ b/helper/atomicfiles/AGENTS.md
@@ -1,0 +1,29 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# atomicfiles
+
+## Purpose
+Provides atomic file write operations — writes to a temp file then renames, ensuring no partial writes are visible to readers.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `atomicfiles.go` | `WriteFile()` — write-to-temp-then-rename pattern for crash-safe file updates |
+
+## For AI Agents
+
+### Working In This Directory
+- Single-function package. The write pattern is: create temp file in same dir → write → sync → close → rename.
+- Used by the kafka receiver to persist consumer offsets atomically.
+
+### Testing Requirements
+- No dedicated tests; tested implicitly through kafka receiver tests.
+
+## Dependencies
+
+### External
+- Standard library only (`os`, `path`)
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/helper/carbonpb/AGENTS.md
+++ b/helper/carbonpb/AGENTS.md
@@ -1,0 +1,32 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# carbonpb
+
+## Purpose
+Generated protobuf definitions for the carbon gRPC protocol. Defines the `CarbonLink` service and `Payload` message used by the gRPC API and protobuf receiver.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `carbon.proto` | Protobuf schema: `Payload` (metrics batch), `Metric`, `Point` messages, `CarbonLink` service |
+| `carbon.pb.go` | Generated Go code from `carbon.proto` |
+| `gen.go` | `go:generate` directive for protoc code generation |
+
+## For AI Agents
+
+### Working In This Directory
+- **Do not edit `carbon.pb.go` directly** — it is generated. Edit `carbon.proto` and regenerate.
+- Regenerate with: `go generate ./helper/carbonpb/`
+- Uses `gogo/protobuf` (not standard `google.golang.org/protobuf`) for generation.
+
+### Common Patterns
+- The `Payload` message is a batch of `Metric` messages, each with a name and list of `Point` (value + timestamp).
+
+## Dependencies
+
+### External
+- `github.com/gogo/protobuf` — protobuf runtime and code generation
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/helper/carbonzipperpb/AGENTS.md
+++ b/helper/carbonzipperpb/AGENTS.md
@@ -1,0 +1,29 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# carbonzipperpb
+
+## Purpose
+Generated protobuf definitions for the carbonzipper protocol. Shared types used by carbonserver for carbonapi v2 gRPC compatibility.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `carbonzipper.proto` | Protobuf schema for carbonzipper request/response types |
+| `carbonzipper.pb.go` | Generated Go code from `carbonzipper.proto` |
+| `gen.go` | `go:generate` directive for protoc code generation |
+
+## For AI Agents
+
+### Working In This Directory
+- **Do not edit `carbonzipper.pb.go` directly** — regenerate from the proto file.
+- Uses `gogo/protobuf` for generation.
+- These types are largely superseded by `go-graphite/protocol` carbonapi v3 types but still used for backward compatibility.
+
+## Dependencies
+
+### External
+- `github.com/gogo/protobuf`
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/helper/grpcutil/AGENTS.md
+++ b/helper/grpcutil/AGENTS.md
@@ -1,0 +1,26 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# grpcutil
+
+## Purpose
+gRPC server interceptors for request timing and rate limiting used by carbonserver's gRPC endpoint.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `grpcutil.go` | `UnaryServerTimeHandler` — interceptor that logs request payload, peer, and duration. `StreamServerTimeHandler` — same for streaming RPCs. `NewRateLimiter` — token-bucket rate limiter for gRPC calls. |
+
+## For AI Agents
+
+### Working In This Directory
+- Interceptors are wired into carbonserver's gRPC server setup.
+- Rate limiter uses atomic operations for lock-free concurrency.
+
+## Dependencies
+
+### External
+- `google.golang.org/grpc` — gRPC framework
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/helper/qa/AGENTS.md
+++ b/helper/qa/AGENTS.md
@@ -1,0 +1,26 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# qa
+
+## Purpose
+Test helpers shared across packages.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `tmp_dir.go` | `Root()` — creates a temporary directory for a test, calls cleanup on defer |
+
+## For AI Agents
+
+### Working In This Directory
+- Single-function package used by test files throughout the project.
+- `Root(t, func(dir string))` pattern ensures cleanup even on test failure.
+
+## Dependencies
+
+### External
+- Standard library only (`os`, `testing`)
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/helper/stat/AGENTS.md
+++ b/helper/stat/AGENTS.md
@@ -1,0 +1,28 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# stat
+
+## Purpose
+Platform-specific file stat types for accessing file creation time (Ctim) used by carbonserver's file scanning.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `types.go` | Defines `StatCallback` type alias used throughout the project for metrics collection |
+| `stat.go` | Default (non-Linux) stat helper |
+| `stat_linux.go` | Linux-specific stat with `Ctim` (creation time) access via `syscall.Stat_t` |
+
+## For AI Agents
+
+### Working In This Directory
+- Platform-specific files use build tags (filename convention `_linux.go`).
+- `StatCallback` is `func(metric string, value float64)` — the universal stat reporting signature.
+
+## Dependencies
+
+### External
+- Standard library (`syscall`)
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/helper/stat/AGENTS.md
+++ b/helper/stat/AGENTS.md
@@ -4,25 +4,27 @@
 # stat
 
 ## Purpose
-Platform-specific file stat types for accessing file creation time (Ctim) used by carbonserver's file scanning.
+Platform-specific file stat helpers for accessing file metadata (size, real size, atime, ctime, mtime). Used by carbonserver's file scanning to get accurate file statistics across platforms.
 
 ## Key Files
 
 | File | Description |
 |------|-------------|
-| `types.go` | Defines `StatCallback` type alias used throughout the project for metrics collection |
-| `stat.go` | Default (non-Linux) stat helper |
-| `stat_linux.go` | Linux-specific stat with `Ctim` (creation time) access via `syscall.Stat_t` |
+| `types.go` | Defines `FileStats` struct: Size, RealSize (blocks*512), ATime, CTime, MTime with nanosecond variants |
+| `stat.go` | Non-Linux `GetStat()` — extracts `FileStats` from `os.FileInfo`, falls back to MTime for CTime |
+| `stat_linux.go` | Linux `GetStat()` — uses `syscall.Stat_t` to provide real ATime and CTime via `Atim`/`Ctim` |
 
 ## For AI Agents
 
 ### Working In This Directory
-- Platform-specific files use build tags (filename convention `_linux.go`).
-- `StatCallback` is `func(metric string, value float64)` — the universal stat reporting signature.
+- Platform-specific files use build tag convention (`_linux.go` suffix).
+- `GetStat(os.FileInfo) FileStats` is the single public function — same signature on all platforms, different implementations.
+- On non-Linux, CTime falls back to MTime since `syscall.Stat_t` doesn't expose `Ctim` on all platforms.
+- `RealSize` is calculated from `Blocks * 512` to account for sparse files.
 
 ## Dependencies
 
 ### External
-- Standard library (`syscall`)
+- Standard library only (`os`, `syscall`)
 
 <!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/persister/AGENTS.md
+++ b/persister/AGENTS.md
@@ -1,0 +1,61 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# persister
+
+## Purpose
+Writes cached metrics to Whisper (`.wsp`) files on disk. Manages a worker pool
+that drains the cache's WriteoutQueue, creating or updating whisper files
+according to retention schemas, aggregation rules, and optional per-namespace
+quotas. Also supports online migration of whisper file configuration without
+downtime.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `whisper.go` | Core `Whisper` struct and worker pool. Workers shard by `crc32(metricName) % workersCount`. Handles sparse file creation, `flock`, compressed whisper, hash filenames for tagged metrics, and online migration. Uses 32768 (`storeMutexCount`) sharded mutexes for per-file locking. |
+| `whisper_schema.go` | Parses `storage-schemas.conf`. Maps metric name regex patterns to `whisper.Retentions`. `WhisperSchemas.Match()` returns the first matching schema. |
+| `whisper_schema_test.go` | Tests for schema parsing and matching. |
+| `whisper_aggregation.go` | Parses `storage-aggregation.conf`. Maps metric name patterns to aggregation method (`average`, `sum`, `min`, `max`, `last`) and `xFilesFactor`. Default: `average` / `0.5`. |
+| `whisper_quota.go` | Parses `storage-quotas.conf` (go-carbon-specific). Defines per-namespace limits on metric count, logical/physical size, data points, and throughput with a configurable dropping policy. |
+| `ini.go` | INI file parser used by schemas, aggregation, and quotas config files. Implements the standard Graphite INI format (not TOML). |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- The `Whisper` struct embeds `helper.Stoppable`; use `Stop()` / wait patterns from that helper for graceful shutdown.
+- File-level locking uses `storeMutex[crc32(path) % storeMutexCount]` — 32768 mutexes sharded by path hash. Never hold multiple mutexes simultaneously to avoid deadlock.
+- `hashFilenames` mode hashes tagged metric names to avoid filesystem path length limits (`maxPathLength = 4095`, `maxFilenameLength = 255`). Tagged metric detection lives in the `tags` package.
+- Online migration (`onlineMigration`) live-updates retention, `xFilesFactor`, and aggregation method in existing whisper files. It is rate-limited via `helper.ThrottleTicker`. Controlled globally by `persister.Whisper` flags but can be overridden per-schema or per-aggregation entry.
+- Config files (`storage-schemas.conf`, `storage-aggregation.conf`, `storage-quotas.conf`) use INI format parsed by `ini.go`, not TOML. Do not introduce TOML parsing here.
+- `WhisperSchemas` and `WhisperAggregation` are matched in order of descending `Priority`. Ensure new schemas/aggregation entries set a meaningful priority.
+
+### Testing Requirements
+```
+go test ./persister/
+```
+Includes `whisper_schema_test.go` and `whisper_stop_test.go`. The stop test verifies graceful shutdown of the worker pool.
+
+### Common Patterns
+- Sharded mutex pattern: `storeMutex[crc32.ChecksumIEEE([]byte(path)) % storeMutexCount]`.
+- Rate limiting via `helper.ThrottleTicker` for both `maxUpdatesPerSecond` and online migration rate.
+- Prometheus counters (`created`, `updateOperations`, `committedPoints`, `oooDiscardedPoints`) are updated via `atomic.AddUint32`.
+- Structured logging via `go.uber.org/zap` (field-based, not `fmt.Sprintf`). Separate `logger` and `createLogger` fields for normal vs. file-creation log lines.
+
+## Dependencies
+
+### Internal
+- `github.com/go-graphite/go-carbon/helper` — `Stoppable`, `ThrottleTicker`, `StatCallback`
+- `github.com/go-graphite/go-carbon/points` — `Points` struct from the WriteoutQueue
+- `github.com/go-graphite/go-carbon/tags` — Tagged metric detection and filename hashing
+
+### External
+- `github.com/go-graphite/go-whisper` — Whisper file read/write library
+- `go.uber.org/zap` — Structured logging
+- `github.com/prometheus/client_golang/prometheus` — Prometheus metrics
+- `github.com/lomik/zapwriter` — zap writer initialization
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/points/AGENTS.md
+++ b/points/AGENTS.md
@@ -1,0 +1,52 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# points
+
+## Purpose
+Foundational data types for go-carbon. Defines the `Point` (value + timestamp) and `Points` (metric name + slice of points) structs used everywhere in the pipeline. Also provides text and binary serialization, deserialization, and the `Glue` batching helper used by the collector for remote metric forwarding. Every other package imports this one — it must stay dependency-free of other go-carbon packages.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `points.go` | `Point{Value float64, Timestamp int64}` and `Points{Metric string, Data []Point}`; constructors `New()`, `OnePoint()`, `NowPoint()`; `Add()`, `Append()`, `Copy()`, `Eq()`; `WriteTo()` (plain text), `WriteBinaryTo()` (delta-varint encoding); `ParseText()` for the `"metric value timestamp\n"` line protocol |
+| `glue.go` | `Glue(exit, in, chunkSize, chunkTimeout, callback)` — reads `*Points` from a channel, serializes to plain-text lines, batches into chunks by size or timeout, invokes callback; used by `Collector` for remote TCP/UDP metric forwarding |
+| `reader.go` | `ReadPlain()`, `ReadBinary()`, `ReadFromFile()` — stream readers for dump files; `ReadFromFile` auto-detects binary vs plain by `.bin` suffix |
+| `points_test.go` | Tests for constructors, `ParseText`, `Eq`, `WriteBinaryTo`/`ReadBinary` round-trips |
+| `reader_test.go` | Tests for `ReadPlain`, `ReadBinary`, and `ReadFromFile` |
+
+## For AI Agents
+
+### Working In This Directory
+- This package must have zero imports from other go-carbon packages. Before adding any import, check that it does not create a cycle. The only allowed imports are from the Go standard library.
+- Binary encoding in `WriteBinaryTo()` uses delta-varint compression: the first point stores absolute value and timestamp, subsequent points store deltas. `ReadBinary()` in `reader.go` reverses this with a running accumulator. Any change to the encoding must update both sides simultaneously.
+- `ParseText()` parses the Graphite plaintext protocol: `"<metric> <value> <timestamp>\n"`. It accepts float timestamps (truncates to int64) and rejects NaN values. The commented-out range checks (1980–2100) are intentionally disabled — do not re-enable without discussion.
+- `Glue()` is used exclusively by `carbon.Collector` for the remote-endpoint code path. It is not used for normal cache operations.
+- `MetaMetric` at the bottom of `points.go` is a stub for a planned feature (realtime metric size updates). Do not remove it, but do not build on it without verifying current status.
+- `ReadFromFile()` dispatches to binary or plain reader based on filename suffix `.bin` (case-insensitive). Dump files written by `cache.DumpBinary()` always use `.bin`; xlog files written during graceful stop use plain text.
+
+### Testing Requirements
+```
+go test ./points/
+```
+All tests are self-contained with no filesystem or network dependencies.
+
+### Common Patterns
+- Constructors return `*Points`. Single-point construction: `points.OnePoint(metric, value, timestamp)`. Current-time shorthand: `points.NowPoint(metric, value)`.
+- Chained builder style: `p.Add(value, timestamp).Add(value2, timestamp2)` — `Add()` returns `*Points`.
+- Equality check via `Eq()` compares metric name and all point values/timestamps element-by-element. Used in tests.
+- `WriteTo(w io.Writer)` writes one `"metric value timestamp\n"` line per data point — the standard Graphite plaintext format.
+
+## Dependencies
+
+### Internal
+None. This package has no imports from other go-carbon packages by design.
+
+### External
+Standard library only:
+- `encoding/binary` — varint encoding for binary dump format
+- `bufio`, `io`, `os` — buffered reading for dump files
+- `math` — `Float64bits` / `Float64frombits` for lossless float encoding
+- `strconv`, `strings`, `fmt`, `time` — text parsing and formatting
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/receiver/AGENTS.md
+++ b/receiver/AGENTS.md
@@ -1,0 +1,67 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# receiver
+
+## Purpose
+Plugin-based metric ingestion layer. Provides a protocol registry that allows
+multiple receiver types (TCP, UDP, HTTP, Kafka, Google Cloud Pub/Sub) to be
+instantiated from TOML configuration and feed parsed metric points into the
+cache via a shared `store` callback.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `receiver.go` | Plugin registry. Defines the `Receiver` interface (`Stop()`, `Stat()`, `InitPrometheus()`), the global `protocolMap`, `Register()` to add a protocol, `New()` to instantiate a receiver from a TOML options map, and `WithProtocol()` to serialize typed options into a map with a `protocol` key. |
+| `tcp/` | TCP plaintext and pickle receiver |
+| `udp/` | UDP plaintext receiver |
+| `http/` | HTTP receiver (POST metrics) |
+| `kafka/` | Apache Kafka consumer receiver |
+| `pubsub/` | Google Cloud Pub/Sub receiver |
+| `parse/plain.go` | Plaintext `metric value timestamp\n` parser |
+| `parse/pickle.go` | Python pickle format parser |
+| `parse/protobuf.go` | Protocol Buffers metric parser |
+| `parse/msgpack.go` | MessagePack metric parser |
+
+## Subdirectories
+| Directory | Purpose |
+|-----------|---------|
+| `tcp/` | TCP receiver — plaintext and pickle protocols |
+| `udp/` | UDP receiver — plaintext protocol |
+| `http/` | HTTP receiver — accepts POSTed metrics |
+| `kafka/` | Kafka consumer receiver |
+| `pubsub/` | Google Cloud Pub/Sub receiver |
+| `parse/` | Format parsers for all ingestion protocols |
+
+## For AI Agents
+
+### Working In This Directory
+- The `Receiver` interface has exactly three methods: `Stop()`, `Stat(helper.StatCallback)`, and `InitPrometheus(prometheus.Registerer)`. All protocol implementations must satisfy this interface.
+- Each protocol package (e.g. `tcp`, `udp`) calls `receiver.Register()` from its own `init()` or `Register()` function. These are wired up in `carbon/app.go` inside `registerPluginsOnce`.
+- Configuration round-trips through TOML: `WithProtocol()` encodes a typed options struct to TOML and back to `map[string]interface{}`, appending a `"protocol"` key. `New()` reverses this to decode into the protocol's options type.
+- To add a new protocol: create a subdirectory, define an options struct with TOML tags, implement `Receiver`, call `receiver.Register()` with a name, an options factory (`func() interface{}`), and a receiver factory, then call your `Register()` from `carbon/app.go`.
+- The `store func(*points.Points)` callback passed to each receiver is the write path into the in-memory cache. Do not bypass it.
+
+### Testing Requirements
+```
+go test ./receiver/...
+```
+Parser tests live in `receiver/parse/` and include benchmark (`bench_test.go`) and format-specific tests.
+
+### Common Patterns
+- Protocol registration via `receiver.Register()` at init time (plugin registry pattern).
+- Options structs use `toml` struct tags and are round-tripped through TOML encoding for config decoding — do not use `json` tags here.
+- `helper.StatCallback` is used for internal graphite self-monitoring stats; implement it in every new receiver.
+- Prometheus metrics are registered via `InitPrometheus(prometheus.Registerer)` — use a `prometheus.Registerer` (not the default registry) so tests can register without conflicts.
+
+## Dependencies
+
+### Internal
+- `github.com/go-graphite/go-carbon/helper` — `StatCallback`, `Stoppable`
+- `github.com/go-graphite/go-carbon/points` — `Points` struct passed through the store callback
+
+### External
+- `github.com/BurntSushi/toml` — TOML encoding/decoding for options round-trip
+- `github.com/prometheus/client_golang/prometheus` — Prometheus metrics registration
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/receiver/http/AGENTS.md
+++ b/receiver/http/AGENTS.md
@@ -1,0 +1,35 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# http
+
+## Purpose
+HTTP receiver for Graphite plaintext protocol over HTTP POST requests.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `http.go` | `HTTP` struct — accepts POST requests with plaintext metrics in the body. Configurable max message size (default 64MB). |
+| `http_test.go` | Integration tests |
+| `stop_test.go` | Graceful shutdown tests |
+
+## For AI Agents
+
+### Working In This Directory
+- Default listen port: `:2007`.
+- Reads the full request body, splits by newline, parses each line via `parse.Plain()`.
+- `MaxMessageSize` limits body size to prevent memory exhaustion.
+
+### Testing Requirements
+- `go test ./receiver/http/`
+
+## Dependencies
+
+### Internal
+- `receiver/`, `receiver/parse/`, `points/`, `helper/`
+
+### External
+- `prometheus/client_golang`
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/receiver/kafka/AGENTS.md
+++ b/receiver/kafka/AGENTS.md
@@ -1,0 +1,36 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# kafka
+
+## Purpose
+Apache Kafka receiver for consuming metrics from Kafka topics. Supports multiple message formats and consumer group management.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `kafka.go` | `Kafka` struct — Sarama consumer group that reads metrics from Kafka topics. Supports plaintext, pickle, protobuf, and msgpack formats. Persists consumer offsets atomically to disk. Custom `Offset` type handles "newest"/"oldest" config values. |
+
+## For AI Agents
+
+### Working In This Directory
+- Uses IBM/sarama Kafka client library.
+- Message format is configurable: `plain`, `pickle`, `protobuf`, `msgpack`.
+- Offsets can be persisted to a local file (via `helper/atomicfiles`) as backup beyond Kafka's consumer group offsets.
+- TLS, SASL, and Kerberos authentication supported via config.
+- Custom `Offset` type with `MarshalText`/`UnmarshalText` for TOML config parsing of "newest"/"oldest" strings.
+
+### Testing Requirements
+- `go test ./receiver/kafka/` — requires no real Kafka broker (uses mocks).
+
+## Dependencies
+
+### Internal
+- `receiver/`, `receiver/parse/`, `points/`, `helper/`, `helper/atomicfiles/`
+
+### External
+- `github.com/IBM/sarama` — Apache Kafka client
+- `prometheus/client_golang`
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/receiver/parse/AGENTS.md
+++ b/receiver/parse/AGENTS.md
@@ -1,0 +1,55 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# parse
+
+## Purpose
+Metric parsing functions for all supported message formats. Used by all receivers to deserialize incoming metric data into `points.Points`.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `plain.go` | `Plain()` — parses Graphite plaintext format: `metric.name value timestamp\n` |
+| `pickle.go` | `Pickle()` — parses Python pickle-encoded metric batches |
+| `protobuf.go` | `Protobuf()` — parses `carbonpb.Payload` protobuf messages |
+| `msgpack.go` | `Msgpack()` — parses msgpack-encoded metrics (carbon-relay-ng format) |
+| `plain_test.go` | Plaintext parser tests |
+| `pickle_test.go` | Pickle parser tests |
+| `protobuf_test.go` | Protobuf parser tests |
+| `msgpack_test.go` | Msgpack parser tests |
+| `bench_test.go` | Benchmarks for all parse formats |
+| `common_test.go` | Shared test helpers |
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `data/` | Test fixture data files for parser tests |
+
+## For AI Agents
+
+### Working In This Directory
+- Each parser is a single function: `func([]byte) ([]*points.Points, error)`.
+- Plaintext format: `metric.name value timestamp\n` — the standard Graphite line protocol.
+- Pickle uses `lomik/graphite-pickle` library for Python pickle deserialization.
+- Protobuf uses `helper/carbonpb` generated types.
+- Msgpack is specifically for `carbon-relay-ng` compatibility.
+- All parsers return a slice of `*points.Points` (one per unique metric name in the batch).
+
+### Testing Requirements
+- `go test ./receiver/parse/`
+- `go test -bench=. ./receiver/parse/` for performance benchmarks.
+
+## Dependencies
+
+### Internal
+- `points/` — output data type
+- `helper/carbonpb/` — protobuf message types
+
+### External
+- `lomik/graphite-pickle` — pickle decoder
+- `gogo/protobuf` — protobuf runtime
+- `vmihailenco/msgpack/v5` — msgpack decoder
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/receiver/pubsub/AGENTS.md
+++ b/receiver/pubsub/AGENTS.md
@@ -1,0 +1,35 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# pubsub
+
+## Purpose
+Google Cloud Pub/Sub receiver for consuming metrics from a Pub/Sub subscription.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `pubsub.go` | `PubSub` struct — subscribes to a GCP Pub/Sub subscription, parses messages as plaintext metrics. Supports gzip-compressed messages. Configurable goroutine count and max outstanding messages/bytes. |
+| `pubsub_test.go` | Tests using mock Pub/Sub server |
+
+## For AI Agents
+
+### Working In This Directory
+- Uses `cloud.google.com/go/pubsub` client library.
+- Automatically detects and decompresses gzip'd messages (pooled gzip readers for efficiency).
+- Configured via TOML `[[receiver.pubsub]]` section with project, subscription, goroutine count.
+
+### Testing Requirements
+- `go test ./receiver/pubsub/` — uses a mock Pub/Sub server, no real GCP needed.
+
+## Dependencies
+
+### Internal
+- `receiver/`, `receiver/parse/`, `points/`, `helper/`
+
+### External
+- `cloud.google.com/go/pubsub` — Google Cloud Pub/Sub client
+- `prometheus/client_golang`
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/receiver/tcp/AGENTS.md
+++ b/receiver/tcp/AGENTS.md
@@ -1,0 +1,44 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# tcp
+
+## Purpose
+TCP receiver for plaintext, pickle, and protobuf Graphite protocols over TCP connections. Registers three protocols: `tcp`, `pickle`, and `protobuf`.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `tcp.go` | `TCP` struct — plaintext line protocol receiver. `Register()` registers tcp/pickle/protobuf protocols. Supports compression (gzip, snappy). |
+| `tcp_test.go` | Integration tests for TCP receiver |
+| `pickle_test.go` | Tests for pickle protocol framing |
+| `protobuf_test.go` | Tests for protobuf protocol framing |
+| `stop_test.go` | Graceful shutdown tests |
+
+## For AI Agents
+
+### Working In This Directory
+- `Register()` registers **three** protocols: `tcp` (plaintext), `pickle` (Python pickle framing), `protobuf` (length-prefixed protobuf).
+- Pickle and protobuf use `FramingOptions` with length-prefixed message framing.
+- TCP plaintext parses one metric per line via `parse.Plain()`.
+- Compression support: gzip and snappy decompression on incoming connections.
+
+### Testing Requirements
+- `go test ./receiver/tcp/`
+- Tests spin up real TCP listeners on random ports.
+
+## Dependencies
+
+### Internal
+- `receiver/` — plugin registry
+- `receiver/parse/` — metric parsing
+- `points/` — data types
+- `helper/` — `Stoppable` lifecycle
+
+### External
+- `klauspost/compress` — gzip and snappy decompression
+- `lomik/graphite-pickle/framing` — pickle message framing
+- `prometheus/client_golang` — metrics
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/receiver/udp/AGENTS.md
+++ b/receiver/udp/AGENTS.md
@@ -1,0 +1,37 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# udp
+
+## Purpose
+UDP receiver for Graphite plaintext protocol. Receives one metric per line from UDP datagrams.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `udp.go` | `UDP` struct — reads datagrams, splits by newline, parses via `parse.Plain()`. Optional internal buffer channel. |
+| `udp_test.go` | Integration tests |
+| `stop_test.go` | Graceful shutdown tests |
+
+## For AI Agents
+
+### Working In This Directory
+- Simplest receiver: reads UDP packets, splits by `\n`, parses each line as plaintext metric.
+- Default listen port: `:2003` (same as TCP — both can run simultaneously).
+- `BufferSize` option adds an internal channel buffer between packet reading and cache storage.
+
+### Testing Requirements
+- `go test ./receiver/udp/`
+
+## Dependencies
+
+### Internal
+- `receiver/` — plugin registry
+- `receiver/parse/` — `Plain()` parser
+- `points/`, `helper/`
+
+### External
+- `prometheus/client_golang`
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/tags/AGENTS.md
+++ b/tags/AGENTS.md
@@ -1,0 +1,50 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# tags
+
+## Purpose
+Handles Graphite tagged metrics: normalizes tag strings into canonical form and manages a persistent queue for sending tagged metric names to an external TagDB service. This implements the tagged metrics support described in [Graphite tag documentation](https://graphite.readthedocs.io/en/latest/tags.html).
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `normalize.go` | Tag normalization. `Normalize(s)` — public function, sorts tags by key, deduplicates, returns canonical `metric;tag1=val1;tag2=val2` form. `normalizeOriginal(s)` — mirrors Python carbon's normalization. `FilePath(root, s, hashOnly)` — maps a tagged metric name to an on-disk path under `_tagged/`, using SHA256 hash prefix sharding. |
+| `tags.go` | Package-level wiring (top-level type definitions or init logic). |
+| `queue.go` | `Queue` struct — LevelDB-backed persistent queue. `NewQueue()`, `Add(metric)`, `Stop()`, `Lag()`. Background worker (`sendWorker`) drains the queue in configurable chunk sizes via a user-supplied `send func([]string) error` callback. Handles corrupted LevelDB by moving and recreating. |
+| `normalize_test.go` | Tests for `Normalize` and `FilePath`. |
+| `queue_test.go` | Tests for `Queue` (add/send lifecycle). |
+
+## For AI Agents
+
+### Working In This Directory
+- Tagged metric format: `metricname;key1=val1;key2=val2`. Metrics without `;` are skipped by `Queue.Add` and are treated as untagged.
+- `Normalize` uses a stable sort (`sort.Stable`) on the tag segment slice — this preserves ordering of equal keys before deduplication.
+- `FilePath` with `hashOnly=false` uses the literal metric string (dots replaced with `_DOT_`) as the filename, sharded into `_tagged/<h0:3>/<h3:6>/`. With `hashOnly=true` only the SHA256 hash is used as filename — safer for very long metric names.
+- LevelDB keys are `uint64 timestamp (big-endian) + metric string`. This ensures iteration order equals insertion order. The `Lag()` method reads the oldest key's timestamp to compute queue depth.
+- The `send` callback is injected at construction time — it should call the TagDB HTTP endpoint. If it returns an error, the batch is retried after 100ms.
+- `Queue` embeds `helper.Stoppable`; call `q.Stop()` for clean shutdown (flushes LevelDB close).
+
+### Testing Requirements
+```
+go test ./tags/
+```
+Both `normalize_test.go` and `queue_test.go` are present. Queue tests use `helper/qa` for temp directories.
+
+### Common Patterns
+- Error handling in `Queue`: LevelDB errors increment atomic counters (`putErrors`, `deleteErrors`, `sendFail`) and are logged via `zapwriter`/`zap` — they do not stop the queue.
+- Stat fields use `sync/atomic` increments, consistent with the rest of go-carbon.
+- The `changed` channel (`cap=1`, non-blocking send) is used as a "work available" signal to the send worker goroutine, avoiding polling latency.
+
+## Dependencies
+
+### Internal
+- `helper/` — `helper.Stoppable` (embedded in `Queue`), `zapwriter` (logging)
+
+### External
+- `github.com/syndtr/goleveldb/leveldb` — persistent queue storage
+- `go.uber.org/zap` — structured logging
+- `github.com/lomik/zapwriter` — logger factory (`zapwriter.Logger("tags")`)
+- `crypto/sha256`, `encoding/binary`, `sort`, `strings` — standard library
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/tool/AGENTS.md
+++ b/tool/AGENTS.md
@@ -1,0 +1,48 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-13 | Updated: 2026-04-13 -->
+
+# tool
+
+## Purpose
+Standalone CLI tools for go-carbon operations and administration. These are compiled binaries, not importable packages. Currently contains one tool for pre-deployment validation of persister configuration changes.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `persister_configs_differ/main.go` | CLI tool to diff persister configs. Reads old and new `storage-schemas.conf` and `storage-aggregation.conf`, iterates over a carbonserver file-list cache (`.gzip`), and reports how many metrics would change schema retention or aggregation method. Outputs a summary of change counts grouped by rule transition (e.g. `60s:7d->10s:30d`). Supports `--print-metrics` to emit each affected metric path. |
+
+## Subdirectories
+| Directory | Purpose |
+|-----------|---------|
+| `persister_configs_differ/` | Source for the `persister_configs_differ` binary |
+
+## For AI Agents
+
+### Working In This Directory
+- This is a `package main` binary, not a library. Do not import it from other packages.
+- The tool reads a carbonserver file-list cache (produced by go-carbon's carbonserver when `file-list-cache` is configured). Pass the `.gzip` cache file via `-file-list-cache`.
+- All four config flags (`-old-schema`, `-new-schema`, `-old-aggregation`, `-new-aggregation`) are required for a meaningful diff — the tool will panic on missing/invalid files.
+- There is a `TODO` comment in the source suggesting this could become a go-carbon sub-command; do not remove it without addressing the underlying design question.
+- Commented-out debug logging (`log.Printf`, counter increments) is intentionally left in the source as scaffolding — do not remove without discussion.
+
+### Testing Requirements
+```
+go build ./tool/...
+```
+No unit tests exist. Validation is done by running the binary against real config files and a file-list cache snapshot.
+
+### Common Patterns
+- Uses `flag` package for CLI argument parsing (standard go-carbon tooling pattern).
+- Panics on errors from config parsing and cache reading — this is intentional for a CLI tool where errors are fatal.
+- Output is plain text to stdout: one section per config type (`schema-changes`, `aggregation-changes`), each line is `old->new count`.
+
+## Dependencies
+
+### Internal
+- `carbonserver/` — `carbonserver.NewFileListCache`, `carbonserver.FLCVersionUnspecified` for reading the metric file-list cache
+- `persister/` — `persister.ReadWhisperSchemas`, `persister.ReadWhisperAggregation` for parsing config files
+
+### External
+- `flag`, `fmt`, `io`, `errors`, `strings` — standard library only
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->


### PR DESCRIPTION
errors.Is checks value equality while errorNotFound is a struct type
that needs type matching. This caused all "Not Found" responses to be
returned as HTTP 500 instead of HTTP 404. The gRPC handler in the same
file already correctly uses errors.As.

Also adding files for AI agents. 